### PR TITLE
Run CI with multiple python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v2
         with:
-          python-version: "${{ matric.python-version }}"
+          python-version: "${{ matrix.python-version }}"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: False
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     name: "Build and Test: Python ${{ matrix.python-version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,15 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9"]
+        allowed-to-fail: [False]
+        include:
+          - python-version: "3.10"
+            allowed-to-fail: True
+          - python-version: "3.11"
+            allowed-to-fail: True
+          - python-version: "3.12"
+            allowed-to-fail: True
     name: "Build and Test: Python ${{ matrix.python-version }}"
     steps:
       - name: Checkout
@@ -33,10 +41,12 @@ jobs:
           python-version: "${{ matrix.python-version }}"
 
       - name: Install dependencies
+        continue-on-fail: ${{ matrix.allowed-to-fail }}
         run: |
           pip install --upgrade pip setuptools wheel
           pip install -e .[dev]
 
       - name: Run tests
+        continue-on-fail: ${{ matrix.allowed-to-fail }}
         run: |
           pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,12 @@ jobs:
           python-version: "${{ matrix.python-version }}"
 
       - name: Install dependencies
-        continue-on-fail: ${{ matrix.allowed-to-fail }}
+        continue-on-error: ${{ matrix.allowed-to-fail }}
         run: |
           pip install --upgrade pip setuptools wheel
           pip install -e .[dev]
 
       - name: Run tests
-        continue-on-fail: ${{ matrix.allowed-to-fail }}
+        continue-on-error: ${{ matrix.allowed-to-fail }}
         run: |
           pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,19 @@ on:
 
 jobs:
   build:
-    name: "Build and Test"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    name: "Build and Test: Python ${{ matrix.python-version }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "${{ matric.python-version }}"
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
++ CI now runs tests against multiple Python versions. (#2)
+
 
 ## v1.0.0 (2023-01-14)
 


### PR DESCRIPTION
Run CI with multiple python versions.

Testing support for py3.8 through 3.12.